### PR TITLE
First shader, reset Water scene in start version

### DIFF
--- a/2018/06-16-intro-to-shaders-2d-water/start/water/Water.tscn
+++ b/2018/06-16-intro-to-shaders-2d-water/start/water/Water.tscn
@@ -1,16 +1,12 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://water/textures/water_diffuse.png" type="Texture" id=1]
-[ext_resource path="res://water/water.gd" type="Script" id=2]
 
 [node name="Water" type="Sprite" index="0"]
 
-scale = Vector2( 8.08363, 5.91029 )
+scale = Vector2( 5.5, 3 )
 texture = ExtResource( 1 )
 centered = false
-script = ExtResource( 2 )
 _sections_unfolded = [ "Material" ]
-
-[connection signal="item_rect_changed" from="." to="." method="calculate_aspect_ratio"]
 
 

--- a/2018/06-16-intro-to-shaders-2d-water/start/water/water.gd
+++ b/2018/06-16-intro-to-shaders-2d-water/start/water/water.gd
@@ -1,5 +1,0 @@
-tool
-extends Sprite
-
-func calculate_aspect_ratio():
-	material.set_shader_param("aspect_ratio", scale.y / scale.x)


### PR DESCRIPTION
To match https://www.youtube.com/watch?v=U91nqeUe1qQ

I haven't watched further yet, but I guess the `02.uv_texture_offset/` and `03.lighting/` folders might also need to be removed in the "start" version?