### PR TITLE
Fixed player synchronization with more than two instances open

### DIFF
--- a/2018/07-30-2018-multiplayer-high-level-api/Network.gd
+++ b/2018/07-30-2018-multiplayer-high-level-api/Network.gd
@@ -12,6 +12,7 @@ signal server_disconnected
 
 func _ready():
 	get_tree().connect('network_peer_disconnected', self, '_on_player_disconnected')
+	get_tree().connect('network_peer_connected', self, '_on_player_connected')
 
 func create_server(player_nickname):
 	self_data.name = player_nickname
@@ -28,18 +29,31 @@ func connect_to_server(player_nickname):
 	get_tree().set_network_peer(peer)
 
 func _connected_to_server():
-	players[get_tree().get_network_unique_id()] = self_data
-	rpc('_send_player_info', get_tree().get_network_unique_id(), self_data)
+	var local_player_id = get_tree().get_network_unique_id()
+	players[local_player_id] = self_data
+	rpc('_send_player_info', local_player_id, self_data)
 
 func _on_player_disconnected(id):
 	players.erase(id)
 
-remote func _send_player_info(id, info):
+func _on_player_connected(connected_player_id):
+	var local_player_id = get_tree().get_network_unique_id()
+	if not(get_tree().is_network_server()):
+		rpc_id(1, '_request_player_info', local_player_id, connected_player_id)
+
+remote func _request_player_info(request_from_id, player_id):
+	if get_tree().is_network_server():
+		rpc_id(request_from_id, '_send_player_info', player_id, players[player_id])
+
+# A function to be used if needed. The purpose is to request all players in the current session.
+remote func _request_players(request_from_id):
 	if get_tree().is_network_server():
 		for peer_id in players:
-			rpc_id(id, '_send_player_info', peer_id, players[peer_id])
+			if( peer_id != request_from_id):
+				rpc_id(request_from_id, '_send_player_info', peer_id, players[peer_id])
+
+remote func _send_player_info(id, info):
 	players[id] = info
-	
 	var new_player = load('res://player/Player.tscn').instance()
 	new_player.name = str(id)
 	new_player.set_network_master(id)


### PR DESCRIPTION
First of all thanks for the tutorial.

I noticed this issue was also mentioned by youtube user TommyPin95 (1 month ago, in the GDQuest video https://www.youtube.com/watch?v=JAtaeP3Nf74&t=1s - Intro to Multiplayer in Godot (3): Rifle and UI (tutorial)).  

The issue happens when you open more than two instances. The first is the server, the second is a joined player, and the third joins and does not appear in the second. The following changes aim to fix that issue. I tried to keep as simple as possible.

I changed the Network a little-bit to be able to proper send player info. 
By studying how the Godot networking works and reading the current docs of version 3.0.x, the signal "network_peer_connected" of the SceneTree is triggered every time any player connects, and it is triggered in every instance of the game.

My logic was, when a player connects to the game, you will receive first his ID, which is used to request all of his info. 

It will be requested to the the server instance only: 
```
remote func _request_player_info(request_from_id, player_id):
	if get_tree().is_network_server(): 
```

There is no need anymore to loop every player and send their info. They are requested to the server when needed. 

The function `remote func _request_players(request_from_id):` at plural is not used, as the comments says it will be useful only if you want to get all the players info in the current session for some reason.

Hope it helps, it was an exercise for me to understand how Godot's networking works. 

Thanks.