### PR TITLE
Update pathfind to godot 3.1

### DIFF
--- a/2018/03-30-astar-pathfinding/character.gd
+++ b/2018/03-30-astar-pathfinding/character.gd
@@ -12,14 +12,14 @@ var target_position = Vector2()
 var velocity = Vector2()
 
 func _ready():
-	_change_state(IDLE)
+	_change_state(STATES.IDLE)
 
 
 func _change_state(new_state):
-	if new_state == FOLLOW:
-		path = get_parent().get_node('TileMap').get_path(position, target_position)
+	if new_state == STATES.FOLLOW:
+		path = get_parent().get_node('TileMap').find_path(position, target_position)
 		if not path or len(path) == 1:
-			_change_state(IDLE)
+			_change_state(STATES.IDLE)
 			return
 		# The index 0 is the starting cell
 		# we don't want the character to move back to it in this example
@@ -28,13 +28,13 @@ func _change_state(new_state):
 
 
 func _process(delta):
-	if not _state == FOLLOW:
+	if not _state == STATES.FOLLOW:
 		return
 	var arrived_to_next_point = move_to(target_point_world)
 	if arrived_to_next_point:
 		path.remove(0)
 		if len(path) == 0:
-			_change_state(IDLE)
+			_change_state(STATES.IDLE)
 			return
 		target_point_world = path[0]
 
@@ -57,4 +57,4 @@ func _input(event):
 			global_position = get_global_mouse_position()
 		else:
 			target_position = get_global_mouse_position()
-		_change_state(FOLLOW)
+		_change_state(STATES.FOLLOW)

--- a/2018/03-30-astar-pathfinding/pathfind_astar.gd
+++ b/2018/03-30-astar-pathfinding/pathfind_astar.gd
@@ -111,7 +111,7 @@ func calculate_point_index(point):
 	return point.x + map_size.x * point.y
 
 
-func get_path(world_start, world_end):
+func find_path(world_start, world_end):
 	self.path_start_position = world_to_map(world_start)
 	self.path_end_position = world_to_map(world_end)
 	_recalculate_path()


### PR DESCRIPTION
Updating code of pathfind and character to work on godot 3.0 and 3.1.
Note: It was needed to change the name of method get_path(...), because in godot 3.1 there is a method that doesn't receive any arguments with same name, so it causes conflicts.