### PR TITLE
Last commit BROKE this. Gave enum it's name back.

### DIFF
--- a/2018/07-30-2018-multiplayer-high-level-api/player/Player.gd
+++ b/2018/07-30-2018-multiplayer-high-level-api/player/Player.gd
@@ -3,7 +3,7 @@ extends KinematicBody2D
 const MOVE_SPEED = 10.0
 const MAX_HP = 100
 
-enum { UP, DOWN, LEFT, RIGHT, NONE }
+enum MoveDirection { UP, DOWN, LEFT, RIGHT, NONE }
 
 slave var slave_position = Vector2()
 slave var slave_movement = MoveDirection.NONE


### PR DESCRIPTION
Can't do MoveDirection.NONE if you delete MoveDirection.... Just my 2 cents.