### PR TITLE
Update pawn.gd

### DIFF
--- a/2018/06-09-grid-based-movement/pawns/pawn.gd
+++ b/2018/06-09-grid-based-movement/pawns/pawn.gd
@@ -1,4 +1,4 @@
 extends Node2D
 
-enum { ACTOR, OBSTACLE, OBJECT }
-export(CELL_TYPES) var type = ACTOR
+enum CELL_TYPES{ ACTOR, OBSTACLE, OBJECT }
+export(CELL_TYPES) var type = CELL_TYPES.ACTOR


### PR DESCRIPTION
An exported variable must be initialized to a constant expression or have an export hint in the form of an argument to the export keyword .